### PR TITLE
Manual Pypy37 migration

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version10.0.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0.yaml
@@ -23,6 +23,7 @@ numpy:
 - '1.16'
 - '1.16'
 - '1.19'
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -31,6 +32,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+- 3.7.* *_73_pypy
 - 3.9.* *_cpython
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_cuda_compiler_version10.1.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1.yaml
@@ -23,6 +23,7 @@ numpy:
 - '1.16'
 - '1.16'
 - '1.19'
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -31,6 +32,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+- 3.7.* *_73_pypy
 - 3.9.* *_cpython
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_cuda_compiler_version10.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2.yaml
@@ -23,6 +23,7 @@ numpy:
 - '1.16'
 - '1.16'
 - '1.19'
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -31,6 +32,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+- 3.7.* *_73_pypy
 - 3.9.* *_cpython
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_cuda_compiler_version11.0.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0.yaml
@@ -23,6 +23,7 @@ numpy:
 - '1.16'
 - '1.16'
 - '1.19'
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -31,6 +32,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+- 3.7.* *_73_pypy
 - 3.9.* *_cpython
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_cuda_compiler_version9.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2.yaml
@@ -23,6 +23,7 @@ numpy:
 - '1.16'
 - '1.16'
 - '1.19'
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -31,6 +32,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+- 3.7.* *_73_pypy
 - 3.9.* *_cpython
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNone.yaml
@@ -23,6 +23,7 @@ numpy:
 - '1.16'
 - '1.16'
 - '1.19'
+- '1.19'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -31,6 +32,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+- 3.7.* *_73_pypy
 - 3.9.* *_cpython
 target_platform:
 - linux-64

--- a/.ci_support/migrations/pypy37.yaml
+++ b/.ci_support/migrations/pypy37.yaml
@@ -1,0 +1,30 @@
+migrator_ts: 1608144114
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy  # new entry
+    paused: False
+    longterm: True
+    pr_limit: 10
+    bump_number: 0
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+
+python:                # [not (win or arm64)]
+  - 3.7.* *_73_pypy    # [not (win or arm64)]
+# additional entries to add for zip_keys
+numpy:                 # [not (win or arm64)]
+  - 1.19               # [not (win or arm64)]
+python_impl:           # [not (win or arm64)]
+  - pypy               # [not (win or arm64)]

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -18,6 +18,7 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.16'
+- '1.19'
 - '1.16'
 - '1.16'
 - '1.19'
@@ -27,6 +28,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+- 3.7.* *_73_pypy
 - 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython

--- a/recipe/build-pkg.bat
+++ b/recipe/build-pkg.bat
@@ -1,3 +1,7 @@
+:: Set EXT_SUFFIX for swig extension (not strictly necessary, but allows uniform handling in patched CMakeLists.txt)
+for /f "delims=" %%i in ('python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"') do set "EXT_SUFFIX=%%i"
+echo Setting environment variable EXT_SUFFIX to "%EXT_SUFFIX%" (from python-sysconfig)
+
 :: Build vanilla version (no avx2).
 :: Do not use the Python3_* variants for cmake
 cmake -B _build_python ^

--- a/recipe/build-pkg.sh
+++ b/recipe/build-pkg.sh
@@ -16,6 +16,11 @@ else
     FAISS_ENABLE_GPU="OFF"
 fi
 
+# needed by patched CMakeLists.txt for correct PyPy-extension
+export EXT_SUFFIX=$(python -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
+echo "Setting environment variable EXT_SUFFIX to \"${EXT_SUFFIX}\" (from python-sysconfig)"
+
+
 # Build vanilla version (no avx2), see build-lib.sh
 # Do not use the Python3_* variants for cmake
 cmake -B _build_python \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,6 +74,8 @@ source:
     - patches/0001-use-c-14.patch
     # backport of facebookresearch/faiss#1666, can be dropped for ver>1.7.0
     - patches/0002-Add-missing-headers-in-faiss-gpu-CMakeLists.txt-1666.patch
+    # the following patch needs EXT_SUFFIX to be set correctly in build-pkg.{bat|sh}
+    - patches/0003-set-correct-EXT_SUFFIX-for-swig.patch
 
 build:
   number: {{ number }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -182,9 +182,9 @@ outputs:
       imports:
         - faiss
       commands:
-        - pytest tests
+        - pytest tests -v
         # running the following test requires an actual GPU device, which is not available in CI
-        # - pytest faiss/gpu/test/
+        # - pytest faiss/gpu/test/ -v
 
   # for compatibility with (& ease of migration from) existing packages in the pytorch channel
   - name: faiss-cpu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -175,16 +175,16 @@ outputs:
         # - blas * *{{ blas_impl }}
         # testing with MKL, as upstream considers this the most important
         - blas =*=mkl
-        # this is necessary for a single test in the test suite
         - scipy
+        - pytest
       source_files:
         - tests/
       imports:
         - faiss
       commands:
-        - python -m unittest discover tests
+        - pytest tests
         # running the following test requires an actual GPU device, which is not available in CI
-        # - python -m unittest discover faiss/gpu/test/
+        # - pytest faiss/gpu/test/
 
   # for compatibility with (& ease of migration from) existing packages in the pytorch channel
   - name: faiss-cpu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.7.0" %}
-{% set number = 0 %}
+{% set number = 1 %}
 # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
 {% set faiss_proc_type = "cuda" if cuda_compiler_version != "None" else "cpu" %}
 

--- a/recipe/patches/0001-use-c-14.patch
+++ b/recipe/patches/0001-use-c-14.patch
@@ -1,7 +1,7 @@
 From 1b4e6f16de1bc6e6e7a104647625f45956356df5 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Mon, 26 Oct 2020 22:44:44 +0100
-Subject: [PATCH 1/2] use c++14
+Subject: [PATCH 1/3] use c++14
 
 ---
  CMakeLists.txt              | 2 +-

--- a/recipe/patches/0002-Add-missing-headers-in-faiss-gpu-CMakeLists.txt-1666.patch
+++ b/recipe/patches/0002-Add-missing-headers-in-faiss-gpu-CMakeLists.txt-1666.patch
@@ -1,7 +1,7 @@
 From e4b94c8a5ad0fc7632cf05006865dbd8feac2ed4 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 4 Feb 2021 09:21:21 -0800
-Subject: [PATCH 2/2] Add missing headers in faiss/[gpu/]CMakeLists.txt (#1666)
+Subject: [PATCH 2/3] Add missing headers in faiss/[gpu/]CMakeLists.txt (#1666)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/recipe/patches/0003-set-correct-EXT_SUFFIX-for-swig.patch
+++ b/recipe/patches/0003-set-correct-EXT_SUFFIX-for-swig.patch
@@ -1,0 +1,69 @@
+From 1bdc4e2aef10b7b1a07ae25398d1a54d03d5e451 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Wed, 23 Dec 2020 10:22:30 +0100
+Subject: [PATCH 3/3] set correct EXT_SUFFIX for swig
+
+---
+ faiss/python/CMakeLists.txt |  7 +++----
+ faiss/python/setup.py       | 19 ++++++++++---------
+ 2 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/faiss/python/CMakeLists.txt b/faiss/python/CMakeLists.txt
+index 40ef40c1..66a1c525 100644
+--- a/faiss/python/CMakeLists.txt
++++ b/faiss/python/CMakeLists.txt
+@@ -61,10 +61,9 @@ swig_add_library(swigfaiss
+   SOURCES swigfaiss.swig
+ )
+ 
+-if(NOT WIN32)
+-  # NOTE: Python does not recognize the dylib extension.
+-  set_target_properties(swigfaiss PROPERTIES SUFFIX .so)
+-endif()
++# This is set to the value of sysconfig.get_config_var('EXT_SUFFIX') in build-pkg.{bat|sh}
++# For example, PyPy does not recognize the plain "so"-extension; see https://github.com/swig/swig/issues/1912
++set_target_properties(swigfaiss PROPERTIES SUFFIX $ENV{EXT_SUFFIX})
+ 
+ if(FAISS_ENABLE_GPU)
+   find_package(CUDAToolkit REQUIRED)
+diff --git a/faiss/python/setup.py b/faiss/python/setup.py
+index 8a28eeeb..3ee5332d 100644
+--- a/faiss/python/setup.py
++++ b/faiss/python/setup.py
+@@ -7,6 +7,7 @@ from __future__ import print_function
+ from setuptools import setup, find_packages
+ import os
+ import shutil
++import sysconfig
+ import platform
+ 
+ # make the faiss python package dir
+@@ -16,16 +17,16 @@ shutil.copytree("contrib", "faiss/contrib")
+ shutil.copyfile("__init__.py", "faiss/__init__.py")
+ shutil.copyfile("loader.py", "faiss/loader.py")
+ shutil.copyfile("swigfaiss.py", "faiss/swigfaiss.py")
+-if platform.system() == 'Windows':
+-    shutil.copyfile("Release/_swigfaiss.pyd", "faiss/_swigfaiss.pyd")
+ 
+-else:
+-    shutil.copyfile("_swigfaiss.so", "faiss/_swigfaiss.so")
+-    try:
+-        shutil.copyfile("swigfaiss_avx2.py", "faiss/swigfaiss_avx2.py")
+-        shutil.copyfile("_swigfaiss_avx2.so", "faiss/_swigfaiss_avx2.so")
+-    except:
+-        pass
++ext = sysconfig.get_config_var('EXT_SUFFIX')
++prefix = "Release/" * (platform.system() == 'Windows')
++shutil.copyfile(f"{prefix}_swigfaiss{ext}", f"faiss/_swigfaiss{ext}")
++
++try:
++    shutil.copyfile("swigfaiss_avx2.py", "faiss/swigfaiss_avx2.py")
++    shutil.copyfile(f"{prefix}_swigfaiss_avx2{ext}", f"faiss/_swigfaiss_avx2{ext}")
++except:
++    pass
+ 
+ long_description="""
+ Faiss is a library for efficient similarity search and clustering of dense
+-- 
+2.29.2.windows.3
+


### PR DESCRIPTION
Manual migration for pypy37 (which might hopefully fare better than the segfaults that had appeared in #22), since all dependencies are built but the migrator has a resolver problem (see [status](https://conda-forge.org/status/)):
```
faiss-split (0) Error: not solvable: master:
osx_64_: Encountered problems while solving.
Problem: nothing provides openblas 0.3.5.* needed by libblas-3.8.0-4_openblas
```