### PR TITLE
Change cmake virtual and real cuda arch flags to avoid extra JIT compilation

### DIFF
--- a/recipe/build-lib.sh
+++ b/recipe/build-lib.sh
@@ -16,27 +16,27 @@ if [ ${cuda_compiler_version} != "None" ]; then
     DEPRECATED_IN_11=(35 50)
     if [ $(version2int $cuda_compiler_version) -ge $(version2int "11.1") ]; then
         # Ampere support for GeForce 30 (sm_86) needs cuda >= 11.1
-        ARCHES=( "${ARCHES[@]}" 75 80 86 )
+        ARCHES=( "${ARCHES[@]}" 75 80 )
         LATEST_ARCH=86
     elif [ $(version2int $cuda_compiler_version) -ge $(version2int "11.0") ]; then
         # Ampere support for A100 (sm_80) needs cuda >= 11.0
-        ARCHES=( "${ARCHES[@]}" 75 80 )
+        ARCHES=( "${ARCHES[@]}" 75 )
         LATEST_ARCH=80
     elif [ $(version2int $cuda_compiler_version) -ge $(version2int "10.0") ]; then
         # Turing support (sm_75) needs cuda >= 10.0
-        ARCHES=( "${DEPRECATED_IN_11[@]}" "${ARCHES[@]}" 75 )
+        ARCHES=( "${DEPRECATED_IN_11[@]}" "${ARCHES[@]}" )
         LATEST_ARCH=75
     else  # 9.x
         ARCHES=( "${DEPRECATED_IN_11[@]}" "${ARCHES[@]}" )
         LATEST_ARCH=70
     fi
     for arch in "${ARCHES[@]}"; do
-        CMAKE_CUDA_ARCHS="${CMAKE_CUDA_ARCHS+${CMAKE_CUDA_ARCHS};}${arch}-virtual"
+        CMAKE_CUDA_ARCHS="${CMAKE_CUDA_ARCHS+${CMAKE_CUDA_ARCHS};}${arch}-real"
     done
     # for -real vs. -virtual, see cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html
     # this is to support PTX JIT compilation; see first link above or cf.
     # devblogs.nvidia.com/cuda-pro-tip-understand-fat-binaries-jit-caching
-    CMAKE_CUDA_ARCHS="${CMAKE_CUDA_ARCHS+${CMAKE_CUDA_ARCHS};}${LATEST_ARCH}-real"
+    CMAKE_CUDA_ARCHS="${CMAKE_CUDA_ARCHS+${CMAKE_CUDA_ARCHS};}${LATEST_ARCH}"
 
     FAISS_ENABLE_GPU="ON"
     CUDA_CONFIG_ARGS+=(

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.7.0" %}
-{% set number = 4 %}
+{% set number = 5 %}
 # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
 {% set faiss_proc_type = "cuda" if cuda_compiler_version != "None" else "cpu" %}
 


### PR DESCRIPTION
Closes #36 

See issue for a detailed description: https://github.com/conda-forge/faiss-split-feedstock/issues/36#issuecomment-797499145

Will be testing it later today to confirm issues are solved and will change from draft then (it just takes quite a while to compile the conda package locally). 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
