### PR TITLE
don't build for CUDA_ARCH 86 on 11.1 due to time outs

### DIFF
--- a/recipe/build-lib.bat
+++ b/recipe/build-lib.bat
@@ -26,8 +26,10 @@ if "%cuda_compiler_version%"=="None" (
         if "%cuda_compiler_version:~0,4%"=="11.0" (
             REM cuda 11.0 deprecates arches 35, 50
             set "CMAKE_CUDA_ARCHS=52-real;60-real;61-real;70-real;75-real;80"
+        ) else if "%cuda_compiler_version:~0,4%"=="11.1" (
+            REM cuda>=11.1 adds arch 86, but we only build that for 11.2+ because 11.1 times out otherwise
+            set "CMAKE_CUDA_ARCHS=52-real;60-real;61-real;70-real;75-real;80"
         ) else (
-            REM cuda>=11.1 adds arch 86
             set "CMAKE_CUDA_ARCHS=52-real;60-real;61-real;70-real;75-real;80-real;86"
         )
     )

--- a/recipe/build-lib.sh
+++ b/recipe/build-lib.sh
@@ -75,7 +75,6 @@ cmake -B _build_${CF_FAISS_BUILD} \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_LIBDIR=lib \
       ${CUDA_CONFIG_ARGS+"${CUDA_CONFIG_ARGS[@]}"} \
-      --verbose \
       .
 
 cmake --build _build_${CF_FAISS_BUILD} -j $CPU_COUNT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -217,42 +217,22 @@ outputs:
         - blas =*=mkl
         - scipy
         - pytest
+      files:
+        - test-pkg.bat
+        - test-pkg.sh
       source_files:
         - tests/
       imports:
         - faiss
       commands:
-        {% if not (osx or py36) %}
         # the linux & windows CI agents support AVX2 (OSX doesn't yet), so by default,
         # we expect faiss will load the library with AVX2-support, see
-        # https://github.com/facebookresearch/faiss/blob/master/faiss/python/loader.py#L48-L60
-        - python -c "from numpy.core._multiarray_umath import __cpu_features__; print(f'Testing version with AVX2-support - ' + str(__cpu_features__['AVX2']))"
-        - pytest tests --log-file-level=INFO --log-file=log.txt                         # [not win]
-        # TestComputeGT switches between CPU & GPU implementation depending on availability;
-        # GPU detection on windows is currently broken in CUDA, and would therefore break the test suite
-        - pytest tests --log-file-level=INFO --log-file=log.txt -k "not TestComputeGT"  # [win]
-        # print logfile for completeness (sleep so log has time to print)
-        - cat log.txt && sleep 2  # [not win]
-        - type log.txt            # [win]
-        # ensure that expected logger-messages from loader.py is present;
-        # avoid final '\n', as well as the first 35 = len('INFO     faiss.loader:loader.py:51 ')
-        - python -c "q = open('log.txt').readlines(); import sys; sys.exit(0 if 'Successfully loaded faiss with AVX2 support.' in [x[35:-1] for x in q] else 1)"
-        # OTOH, we also want to test the packaged library without AVX2 support;
-        # the advantage of the CPU feature detection in numpy is that it can be
-        # deactivated, see documentation of NPY_DISABLE_CPU_FEATURES upstream;
-        # however, the dict of CPU features is determined (and frozen) upon the
-        # first import, so we cannot run both variants in a single run_test.py
-        - export NPY_DISABLE_CPU_FEATURES=AVX2  # [not win]
-        - set NPY_DISABLE_CPU_FEATURES=AVX2     # [win]
-        {% endif %}
-        - python -c "from numpy.core._multiarray_umath import __cpu_features__; print(f'Testing version with AVX2-support - ' + str(__cpu_features__['AVX2']))"
-        # rerun test suite again without AVX2 support
-        - pytest tests --log-file-level=INFO --log-file=log.txt                         # [not win]
-        - pytest tests --log-file-level=INFO --log-file=log.txt -k "not TestComputeGT"  # [win]
-        - cat log.txt && sleep 2  # [not win]
-        - type log.txt            # [win]
-        # this should have run without AVX2; skip for py36 due to NPY_DISABLE_CPU_FEATURES not working
-        - python -c "q = open('log.txt').readlines(); import sys; sys.exit(0 if 'Successfully loaded faiss.' in [x[35:-1] for x in q] else 1)"  # [py>36]
+        # https://github.com/facebookresearch/faiss/blob/master/faiss/python/loader.py#L52-L66
+        # skip for AVX2+py36 due to NPY_DISABLE_CPU_FEATURES not working (would run AVX2 twice)
+        - export HAS_AVX2=YES && ./test-pkg.sh  # [linux and not py36]
+        - export HAS_AVX2=NO  && ./test-pkg.sh  # [osx or (linux and py36)]
+        - set "HAS_AVX2=YES"  && test-pkg.bat   # [win and not py36]
+        - set "HAS_AVX2=NO"   && test-pkg.bat   # [win and py36]
 
         # running the following test requires an actual GPU device, which is not available in CI
         # - pytest faiss/gpu/test/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -225,6 +225,8 @@ outputs:
       imports:
         - faiss
       commands:
+        # skip test suite on win + cuda 11.1 due to time outs
+        {% if not (win and cuda_compiler_version == "11.1") %}
         # the linux & windows CI agents support AVX2 (OSX doesn't yet), so by default,
         # we expect faiss will load the library with AVX2-support, see
         # https://github.com/facebookresearch/faiss/blob/master/faiss/python/loader.py#L52-L66
@@ -233,6 +235,7 @@ outputs:
         - export HAS_AVX2=NO  && ./test-pkg.sh  # [osx or (linux and py36)]
         - set "HAS_AVX2=YES"  && test-pkg.bat   # [win and not py36]
         - set "HAS_AVX2=NO"   && test-pkg.bat   # [win and py36]
+        {% endif %}
 
         # running the following test requires an actual GPU device, which is not available in CI
         # - pytest faiss/gpu/test/

--- a/recipe/test-pkg.bat
+++ b/recipe/test-pkg.bat
@@ -1,0 +1,39 @@
+@echo on
+
+SetLocal EnableDelayedExpansion
+
+if "%HAS_AVX2%"=="NO" (
+    GOTO Generic
+)
+
+:AVX2
+python -c "from numpy.core._multiarray_umath import __cpu_features__; print(f'Testing version with AVX2-support - ' + str(__cpu_features__['AVX2']))"
+pytest tests --log-file-level=INFO --log-file=log.txt
+if %ERRORLEVEL% neq 0 exit 1
+:: print logfile for completeness
+type log.txt
+
+:: ensure that expected logger-messages from loader.py is present;
+:: avoid final '\n', as well as the first 35 = len('INFO     faiss.loader:loader.py:51 ')
+python -c "q = open('log.txt').readlines(); import sys; sys.exit(0 if 'Successfully loaded faiss with AVX2 support.' in [x[35:-1] for x in q] else 1)"
+if %ERRORLEVEL% neq 0 exit 1
+
+:: Continues with :Generic if coming from :AVX2
+
+:Generic
+:: OTOH, we also want to test the packaged library without AVX2 support;
+:: the advantage of the CPU feature detection in numpy is that it can be
+:: deactivated, see documentation of NPY_DISABLE_CPU_FEATURES upstream
+set NPY_DISABLE_CPU_FEATURES=AVX2
+
+python -c "from numpy.core._multiarray_umath import __cpu_features__; print(f'Testing version with AVX2-support - ' + str(__cpu_features__['AVX2']))"
+:: rerun test suite again without AVX2 support
+pytest tests --log-file-level=INFO --log-file=log.txt
+if %ERRORLEVEL% neq 0 exit 1
+type log.txt
+
+:: this should have run without AVX2; skip for py36 due to NPY_DISABLE_CPU_FEATURES not working
+if not "%PY_VER%"=="3.6" (
+    python -c "q = open('log.txt').readlines(); import sys; sys.exit(0 if 'Successfully loaded faiss.' in [x[35:-1] for x in q] else 1)"
+    if %ERRORLEVEL% neq 0 exit 1
+)

--- a/recipe/test-pkg.sh
+++ b/recipe/test-pkg.sh
@@ -1,0 +1,27 @@
+set -ex
+
+if [[ ${HAS_AVX2} == "YES" ]]; then
+    python -c "from numpy.core._multiarray_umath import __cpu_features__; print(f'Testing version with AVX2-support - ' + str(__cpu_features__['AVX2']))"
+    pytest tests --log-file-level=INFO --log-file=log.txt
+    # print logfile for completeness (sleep so log has time to print)
+    cat log.txt && sleep 2
+
+    # ensure that expected logger-messages from loader.py is present;
+    # avoid final '\n', as well as the first 35 = len('INFO     faiss.loader:loader.py:51 ')
+    python -c "q = open('log.txt').readlines(); import sys; sys.exit(0 if 'Successfully loaded faiss with AVX2 support.' in [x[35:-1] for x in q] else 1)"
+fi
+
+# OTOH, we also want to test the packaged library without AVX2 support;
+# the advantage of the CPU feature detection in numpy is that it can be
+# deactivated, see documentation of NPY_DISABLE_CPU_FEATURES upstream
+export NPY_DISABLE_CPU_FEATURES=AVX2
+
+python -c "from numpy.core._multiarray_umath import __cpu_features__; print(f'Testing version with AVX2-support - ' + str(__cpu_features__['AVX2']))"
+# rerun test suite again without AVX2 support
+pytest tests --log-file-level=INFO --log-file=log.txt
+cat log.txt && sleep 2
+
+# this should have run without AVX2; skip for py36 due to NPY_DISABLE_CPU_FEATURES not working
+if [[ ${PY_VER} != "3.6" ]]; then
+    python -c "q = open('log.txt').readlines(); import sys; sys.exit(0 if 'Successfully loaded faiss.' in [x[35:-1] for x in q] else 1)"
+fi


### PR DESCRIPTION
After 10 CI (re-)runs of the merge commit from #32, win+cuda11.1 is the one build combination that - despite some fluctuation in lib build times between ~1:40 and 4:00 (which is necessary twice; for `libfaiss` and `libfaiss-avx2`) - has not managed to have a successful run.

This is to see if building for one less CUDA arch helps us get under the 6h limit (I have the suspicion from casual observation that 11.1 regressed in terms of compile times, but 11.2 is OK again).

As long as there's no successful [build](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=300698&view=results) for win+cuda11.1, we also don't need to bump the build number here.