### PR TITLE
Fix cuda packages for Linux

### DIFF
--- a/recipe/build-pkg.sh
+++ b/recipe/build-pkg.sh
@@ -2,7 +2,7 @@
 set -ex
 
 FAISS_ENABLE_GPU=""
-if [ ${cuda_compiler_version} != "None" ]; then
+if [ "${cuda_compiler_version}" != "None" ]; then
     FAISS_ENABLE_GPU="ON"
 else
     FAISS_ENABLE_GPU="OFF"
@@ -21,6 +21,7 @@ cmake -G Ninja \
     ${CMAKE_ARGS} \
     -Dfaiss_ROOT=_libfaiss_stage/ \
     -DCMAKE_BUILD_TYPE=Release \
+    -DFAISS_ENABLE_GPU=$FAISS_ENABLE_GPU \
     -DPython_NumPy_INCLUDE_DIR=$SP_DIR/numpy/core/include \
     ../faiss/python
 


### PR DESCRIPTION
Pass `FAISS_ENABLE_GPU` variable to CMake in `build-pkg.sh` script similarly as `build-pkg.bat` does.
Before this change `FAISS_ENABLE_GPU` was effectively just a local variable in that script and wasn't passed anywhere.

It may fix #85 - faiss-gpu (cuda) on Linux.